### PR TITLE
Configure FastAPI port via environment variable

### DIFF
--- a/.github/workflows/production-workflow.yml
+++ b/.github/workflows/production-workflow.yml
@@ -17,6 +17,11 @@ jobs:
       - name: 📥 Checkout do código
         uses: actions/checkout@v4
 
+      - name: 🧪 Rodar testes
+        run: |
+          python -m pip install -e .[test]
+          pytest -q
+
       - name: 📦 Sincronizar arquivos com a VPS (via rsync)
         run: |
           rsync -avz --exclude-from='.rsync-exclude' ./ \

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ __import__('dotenv').load_dotenv()
 
 from pydantic import ValidationError
 from uvicorn import Config, Server
+import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -18,6 +19,9 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI()
 agent = AgentClient()
+# Porta do servico
+def get_service_port() -> int:
+    return int(os.getenv("SERVICE_PORT", "8000"))
 # Configurar CORS
 app.add_middleware(
     CORSMiddleware,
@@ -93,7 +97,7 @@ async def main():
     config = Config(
         app=app,
         host="0.0.0.0",
-        port=8000,
+        port=get_service_port(),
         log_level="info",
         loop='asyncio'
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     build: .
     env_file:
       - ./.env
+    environment:
+      - SERVICE_PORT=${SERVICE_PORT:-8000}
     ports:
-      - 8000:8000
+      - ${SERVICE_PORT:-8000}:${SERVICE_PORT:-8000}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ dependencies = [
     "fastapi[standard]>=0.116.1",
     "uvicorn>=0.35.0",
 ]
+
+[project.optional-dependencies]
+test = ["pytest>=8.4"]

--- a/tests/test_service_port.py
+++ b/tests/test_service_port.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from importlib import reload
+from types import ModuleType
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+def test_service_port_env_var_is_used(monkeypatch):
+    accessed = {}
+
+    def fake_getenv(name, default=None):
+        accessed['name'] = name
+        return '1234'
+
+    monkeypatch.setattr(os, 'getenv', fake_getenv)
+    stub = ModuleType('stub')
+    stub.load_dotenv = lambda: None
+    sys.modules['dotenv'] = stub
+    sys.modules['pydantic'] = ModuleType('pydantic')
+    sys.modules['pydantic'].ValidationError = Exception
+    sys.modules['uvicorn'] = ModuleType('uvicorn')
+    sys.modules['uvicorn'].Config = object
+    sys.modules['uvicorn'].Server = object
+    fastapi_stub = ModuleType('fastapi')
+    class _FastAPI:
+        def add_middleware(self, *a, **k):
+            pass
+        def include_router(self, *a, **k):
+            pass
+    fastapi_stub.FastAPI = _FastAPI
+    sys.modules['fastapi'] = fastapi_stub
+    middleware_module = ModuleType('fastapi.middleware.cors')
+    middleware_module.CORSMiddleware = object
+    sys.modules['fastapi.middleware'] = ModuleType('fastapi.middleware')
+    sys.modules['fastapi.middleware.cors'] = middleware_module
+    sys.modules['models'] = ModuleType('models')
+    sys.modules['models'].ConnectorRequest = object
+    sys.modules['models'].AgentResponse = object
+    sys.modules['session.repository'] = ModuleType('session.repository')
+    sys.modules['session.repository'].SessionEvent = object
+    sys.modules['server.controllers'] = ModuleType('server.controllers')
+    sys.modules['server.controllers'].controller = object
+    sys.modules['server.controllers'].session_repository = object
+    sys.modules['agents.client'] = ModuleType('agents.client')
+    sys.modules['agents.client'].AgentClient = object
+    from app import main
+    reload(main)
+    assert main.get_service_port() == 1234
+    assert accessed.get('name') == 'SERVICE_PORT'


### PR DESCRIPTION
## Summary
- load service port from environment in `app/main.py`
- read SERVICE_PORT in `docker-compose.yml`
- add test verifying SERVICE_PORT is used
- add pytest dependency in pyproject
- add test step to production workflow

## Testing
- `pytest -q`